### PR TITLE
feat: Add light and dark mode support

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,13 +6,18 @@
     <title>Linux Command Generator</title>
     <link rel="stylesheet" href="styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-    <script src="https://kit.fontawesome.com/a076d05399.js" crossorigin="anonymous"></script> <!-- Example for icons, might change -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
 <body>
     <header class="main-header">
-        <div class="container">
-            <h1>Linux Command Generator</h1>
-            <p class="subtitle">Easily build and explore commands for any distro</p>
+        <div class="container header-container">
+            <div>
+                <h1>Linux Command Generator</h1>
+                <p class="subtitle">Easily build and explore commands for any distro</p>
+            </div>
+            <button id="theme-toggle" class="btn-icon">
+                <i class="fas fa-sun"></i>
+            </button>
         </div>
     </header>
 

--- a/script.js
+++ b/script.js
@@ -1,4 +1,25 @@
 document.addEventListener('DOMContentLoaded', () => {
+    // Theme switching logic
+    const themeToggle = document.getElementById('theme-toggle');
+    const body = document.body;
+    const themeIcon = themeToggle.querySelector('i');
+
+    const applyTheme = (theme) => {
+        body.dataset.theme = theme;
+        themeIcon.className = theme === 'dark' ? 'fas fa-moon' : 'fas fa-sun';
+        localStorage.setItem('theme', theme);
+    };
+
+    const preferredTheme = localStorage.getItem('theme') || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+    applyTheme(preferredTheme);
+
+    themeToggle.addEventListener('click', () => {
+        const newTheme = body.dataset.theme === 'dark' ? 'light' : 'dark';
+        applyTheme(newTheme);
+    });
+
+
+    // Command generator logic
     const commands = [
         {
             name: 'ls',

--- a/styles.css
+++ b/styles.css
@@ -5,14 +5,74 @@
     box-sizing: border-box;
 }
 
+:root {
+    --color-background: #f5f5f7;
+    --color-text-primary: #1d1d1f;
+    --color-text-secondary: #6e6e73;
+    --color-text-header: #000;
+    --color-background-card: #ffffff;
+    --color-border: #ddd;
+    --color-border-card: #e5e5e5;
+    --color-border-form: #d2d2d7;
+    --color-accent: #007aff;
+    --color-accent-hover: #005ecb;
+    --color-accent-shadow: rgba(0, 122, 255, 0.3);
+    --color-background-code: #2d2d2d;
+    --color-text-code: #f5f5f7;
+    --color-text-button: #fff;
+    --color-background-pre: #e8e8e8;
+    --shadow-color: rgba(0,0,0,0.05);
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --color-background: #000000;
+        --color-text-primary: #f5f5f7;
+        --color-text-secondary: #86868b;
+        --color-text-header: #f5f5f7;
+        --color-background-card: #1d1d1f;
+        --color-border: #3a3a3c;
+        --color-border-card: #3a3a3c;
+        --color-border-form: #545458;
+        --color-accent: #0a84ff;
+        --color-accent-hover: #0060df;
+        --color-accent-shadow: rgba(10, 132, 255, 0.3);
+        --color-background-code: #2c2c2e;
+        --color-text-code: #f5f5f7;
+        --color-text-button: #fff;
+        --color-background-pre: #2c2c2e;
+        --shadow-color: rgba(0,0,0,0.2);
+    }
+}
+
+body[data-theme="dark"] {
+    --color-background: #000000;
+    --color-text-primary: #f5f5f7;
+    --color-text-secondary: #86868b;
+    --color-text-header: #f5f5f7;
+    --color-background-card: #1d1d1f;
+    --color-border: #3a3a3c;
+    --color-border-card: #3a3a3c;
+    --color-border-form: #545458;
+    --color-accent: #0a84ff;
+    --color-accent-hover: #0060df;
+    --color-accent-shadow: rgba(10, 132, 255, 0.3);
+    --color-background-code: #2c2c2e;
+    --color-text-code: #f5f5f7;
+    --color-text-button: #fff;
+    --color-background-pre: #2c2c2e;
+    --shadow-color: rgba(0,0,0,0.2);
+}
+
 body {
     font-family: 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-    background-color: #f5f5f7;
-    color: #1d1d1f;
+    background-color: var(--color-background);
+    color: var(--color-text-primary);
     line-height: 1.6;
     display: flex;
     flex-direction: column;
     min-height: 100vh;
+    transition: background-color 0.3s, color 0.3s;
 }
 
 .container {
@@ -22,22 +82,28 @@ body {
 }
 
 /* Header */
+.header-container {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
 .main-header {
-    background: #ffffff;
-    padding: 40px 0;
-    text-align: center;
-    border-bottom: 1px solid #ddd;
+    background: var(--color-background-card);
+    padding: 20px 0;
+    border-bottom: 1px solid var(--color-border);
+    transition: background-color 0.3s, border-color 0.3s;
 }
 
 .main-header h1 {
     font-size: 2.5rem;
     font-weight: 700;
-    color: #000;
+    color: var(--color-text-header);
 }
 
 .main-header .subtitle {
     font-size: 1.2rem;
-    color: #6e6e73;
+    color: var(--color-text-secondary);
     margin-top: 8px;
 }
 
@@ -49,16 +115,18 @@ main {
 
 /* Card layout */
 .card {
-    background: #ffffff;
+    background: var(--color-background-card);
     border-radius: 12px;
-    box-shadow: 0 4px 12px rgba(0,0,0,0.05);
+    box-shadow: 0 4px 12px var(--shadow-color);
     margin-bottom: 30px;
     overflow: hidden;
+    transition: background-color 0.3s;
 }
 
 .card-header {
     padding: 20px 25px;
-    border-bottom: 1px solid #e5e5e5;
+    border-bottom: 1px solid var(--color-border-card);
+    transition: border-color 0.3s;
 }
 
 .card-header h2 {
@@ -75,16 +143,17 @@ main {
     width: 100%;
     padding: 12px 15px;
     font-size: 1rem;
-    border: 1px solid #d2d2d7;
+    border: 1px solid var(--color-border-form);
     border-radius: 8px;
-    background-color: #f5f5f7;
-    transition: border-color 0.2s, box-shadow 0.2s;
+    background-color: var(--color-background);
+    color: var(--color-text-primary);
+    transition: border-color 0.2s, box-shadow 0.2s, background-color 0.3s;
 }
 
 .form-control:focus {
     outline: none;
-    border-color: #007aff;
-    box-shadow: 0 0 0 2px rgba(0,122,255,0.3);
+    border-color: var(--color-accent);
+    box-shadow: 0 0 0 2px var(--color-accent-shadow);
 }
 
 /* Options */
@@ -108,8 +177,8 @@ main {
 /* Generated Command */
 .code-block {
     display: block;
-    background: #2d2d2d;
-    color: #f5f5f7;
+    background: var(--color-background-code);
+    color: var(--color-text-code);
     padding: 15px;
     border-radius: 8px;
     font-family: 'SF Mono', 'Menlo', 'Monaco', monospace;
@@ -119,8 +188,8 @@ main {
 
 .btn {
     display: inline-block;
-    background-color: #007aff;
-    color: #fff;
+    background-color: var(--color-accent);
+    color: var(--color-text-button);
     padding: 10px 20px;
     border: none;
     border-radius: 8px;
@@ -132,7 +201,20 @@ main {
 }
 
 .btn:hover {
-    background-color: #005ecb;
+    background-color: var(--color-accent-hover);
+}
+
+.btn-icon {
+    background: transparent;
+    border: none;
+    color: var(--color-text-primary);
+    font-size: 1.5rem;
+    cursor: pointer;
+    transition: color 0.3s;
+}
+
+.btn-icon:hover {
+    color: var(--color-accent);
 }
 
 /* Examples */
@@ -147,19 +229,22 @@ main {
 }
 
 .example pre {
-    background-color: #e8e8e8;
+    background-color: var(--color-background-pre);
+    color: var(--color-text-primary);
     padding: 10px;
     border-radius: 6px;
+    transition: background-color 0.3s, color 0.3s;
 }
 
 /* Footer */
 .main-footer {
-    background: #f5f5f7;
+    background: var(--color-background);
     text-align: center;
     padding: 20px 0;
     font-size: 0.9rem;
-    color: #6e6e73;
-    border-top: 1px solid #ddd;
+    color: var(--color-text-secondary);
+    border-top: 1px solid var(--color-border);
+    transition: background-color 0.3s, border-color 0.3s;
 }
 
 /* Responsive Design */


### PR DESCRIPTION
This commit introduces a theme switcher to the application, allowing users to toggle between light and dark modes.

The implementation includes:
- Refactoring the CSS to use custom properties (variables) for all colors, enabling easy theming.
- A dark theme color palette that is applied when dark mode is active.
- A toggle button in the header with a sun/moon icon to manually switch themes.
- JavaScript logic to handle theme switching, respect the user's system preference (`prefers-color-scheme`), and persist the chosen theme in `localStorage`.